### PR TITLE
#162777854 Update rumor 

### DIFF
--- a/constrollers/rumor.js
+++ b/constrollers/rumor.js
@@ -43,6 +43,12 @@ const getAll = (req, res) => {
     });
 };
 
+/**
+ * Get single rumor
+ * @param {Object} req - request object
+ * @param {Object} res - response object
+ * @return {Object} - response object
+ */
 const getSingle = (req, res) => {
   const rumorId = req.params.id;
   Rumor.findOne({ _id: rumorId }).exec().then((rumorData) => {
@@ -50,7 +56,40 @@ const getSingle = (req, res) => {
   })
     .catch((error) => {
       console.log(error);
-      res.status(400).json({ status: 400, error: 'An error occurred' });
+      res.status(404).json({ status: 404, error: 'An error occurred' });
     });
 };
-export { create, getAll, getSingle };
+
+
+/**
+ * Update single rumor
+ * @param {Object} req - request object
+ * @param {Object} res - response object
+ * @return {Object} - response object
+ */
+const update = (req, res) => {
+  const rumorId = req.params.id;
+  Rumor.findOne({ _id: rumorId }).exec().then((rumorData) => {
+    Rumor.updateOne({ _id: rumorId }, {
+      $set: {
+        title: req.body.title || rumorData.title,
+        content: req.body.content || rumorData.content,
+        location: req.body.location || rumorData.location,
+      },
+    }).exec().then(() => res.status(200).json({ status: 200, data: [{ _id: rumorId, message: 'Rumor updated!' }] }))
+      .catch((error) => {
+        console.log(error);
+        return res.status(400).json({ status: 400, error: 'An error occurred' });
+      });
+  })
+    .catch((error) => {
+      console.log(error);
+      return res.status(404).json({ status: 404, error: 'An error occurred' });
+    });
+};
+export {
+  create,
+  getAll,
+  getSingle,
+  update,
+};

--- a/helpers/validators.js
+++ b/helpers/validators.js
@@ -15,6 +15,14 @@ const validator = (method) => {
           .isString().isLength({ min: 40, max: 1000 }),
       ];
     }
+    case 'update-rumor': {
+      return [
+        check.body('title', 'A valid title is required').optional()
+          .isString().isLength({ min: 5, max: 30 }),
+        check.body('content', 'A valid content is required. Minimum of 40 characters required.').optional()
+          .isString().isLength({ min: 40, max: 1000 }),
+      ];
+    }
     default: {
       return [];
     }

--- a/routes/rumor.js
+++ b/routes/rumor.js
@@ -1,5 +1,10 @@
 import express from 'express';
-import { create, getAll, getSingle } from '../constrollers/rumor';
+import {
+  create,
+  getAll,
+  getSingle,
+  update,
+} from '../constrollers/rumor';
 import validator from '../helpers/validators';
 import handleValidation from '../helpers/handle-validation';
 
@@ -8,5 +13,6 @@ const rumorRouter = express.Router();
 rumorRouter.post('/', validator('create-rumor'), handleValidation, create);
 rumorRouter.get('/', getAll);
 rumorRouter.get('/:id', getSingle);
+rumorRouter.patch('/:id', validator('update-rumor'), handleValidation, update);
 
 export default rumorRouter;

--- a/test/rumor.js
+++ b/test/rumor.js
@@ -66,4 +66,34 @@ describe('Fetch fumors', () => {
       done();
     });
   });
+
+  it('should not get a single rumor with wrong id', (done) => {
+    chai.request(app).get('/api/v1/rumors/' + exampleRumorId + 344).end((err, res) => {
+      res.should.have.status(404);
+      res.body.should.be.a('object');
+      res.body.should.have.property('error');
+      done();
+    });
+  });
+});
+
+describe('Update rumor', () => {
+  it('should update a record', (done) => {
+    chai.request(app).patch('/api/v1/rumors/' + exampleRumorId).send()
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.be.a('object');
+        done();
+      });
+  });
+
+  it('should not update a record with wrong id', (done) => {
+    chai.request(app).patch('/api/v1/rumors/' + exampleRumorId + 992).send()
+      .end((err, res) => {
+        res.should.have.status(404);
+        res.body.should.be.a('object');
+        res.body.should.have.property('error');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
**What does this PR do?**
This pull request adds functionality that enables the server to update rumors

**Tasks to be completed?**
- validate input data
- get rumor with id
- update data
- write tests

**How can this be manually tested?**
- clone the repo
- cd into the directory
- run npm i
- create .env from example.env
- run npm start 
- send patch request to `/api/v1/rumors/:id`

**Relevant PT stories?**
`162777854`