### PR TITLE
#162875245 Add delete rumor

### DIFF
--- a/constrollers/rumor.js
+++ b/constrollers/rumor.js
@@ -52,11 +52,14 @@ const getAll = (req, res) => {
 const getSingle = (req, res) => {
   const rumorId = req.params.id;
   Rumor.findOne({ _id: rumorId }).exec().then((rumorData) => {
+    if (!rumorData) {
+      res.status(404).json({ status: 404, error: 'This Rumor does not exist' });
+    }
     res.status(200).json({ status: 200, data: rumorData });
   })
     .catch((error) => {
       console.log(error);
-      res.status(404).json({ status: 404, error: 'An error occurred' });
+      res.status(400).json({ status: 400, error: 'An error occurred' });
     });
 };
 
@@ -70,13 +73,16 @@ const getSingle = (req, res) => {
 const update = (req, res) => {
   const rumorId = req.params.id;
   Rumor.findOne({ _id: rumorId }).exec().then((rumorData) => {
+    if (!rumorData) {
+      res.status(404).json({ status: 404, error: 'This Rumor does not exist' });
+    }
     Rumor.updateOne({ _id: rumorId }, {
       $set: {
         title: req.body.title || rumorData.title,
         content: req.body.content || rumorData.content,
         location: req.body.location || rumorData.location,
       },
-    }).exec().then(() => res.status(200).json({ status: 200, data: [{ _id: rumorId, message: 'Rumor updated!' }] }))
+    }).exec().then(() => res.status(200).json({ status: 200, data: [{ id: rumorId, message: 'Rumor updated!' }] }))
       .catch((error) => {
         console.log(error);
         return res.status(400).json({ status: 400, error: 'An error occurred' });
@@ -84,7 +90,33 @@ const update = (req, res) => {
   })
     .catch((error) => {
       console.log(error);
-      return res.status(404).json({ status: 404, error: 'An error occurred' });
+      return res.status(400).json({ status: 400, error: 'An error occurred' });
+    });
+};
+
+
+/**
+ * Delete single rumor
+ * @param {Object} req - request object
+ * @param {Object} res - response object
+ * @return {Object} - response object
+ */
+const deleteRumor = (req, res) => {
+  const rumorId = req.params.id;
+  Rumor.findOne({ _id: rumorId }).exec().then((rumorData) => {
+    if (!rumorData) {
+      return res.status(404).json({ status: 404, error: 'This Rumor does not exist' });
+    }
+    Rumor.deleteOne({ _id: rumorId }).exec()
+      .then(() => res.status(200).json({ status: 200, data: [{ _id: rumorId, message: 'Rumor deleted!' }] }))
+      .catch((error) => {
+        console.log(error);
+        return res.status(400).json({ status: 400, error: 'An error occurred' });
+      });
+  })
+    .catch((error) => {
+      console.log(error);
+      return res.status(400).json({ status: 400, error: 'An error occurred' });
     });
 };
 export {
@@ -92,4 +124,5 @@ export {
   getAll,
   getSingle,
   update,
+  deleteRumor,
 };

--- a/routes/rumor.js
+++ b/routes/rumor.js
@@ -4,6 +4,7 @@ import {
   getAll,
   getSingle,
   update,
+  deleteRumor,
 } from '../constrollers/rumor';
 import validator from '../helpers/validators';
 import handleValidation from '../helpers/handle-validation';
@@ -14,5 +15,5 @@ rumorRouter.post('/', validator('create-rumor'), handleValidation, create);
 rumorRouter.get('/', getAll);
 rumorRouter.get('/:id', getSingle);
 rumorRouter.patch('/:id', validator('update-rumor'), handleValidation, update);
-
+rumorRouter.delete('/:id', deleteRumor);
 export default rumorRouter;

--- a/test/rumor.js
+++ b/test/rumor.js
@@ -30,6 +30,7 @@ describe('Test for rumor features', () => {
         res.should.have.status(201);
         res.body.should.have.property('data');
         res.body.should.be.a('object');
+        exampleRumorId = res.body.data[0].id;
         done();
       });
   });
@@ -54,7 +55,6 @@ describe('Fetch fumors', () => {
       res.should.have.status(200);
       res.body.should.be.a('object');
       res.body.should.have.property('data');
-      exampleRumorId = res.body.data[0]._id;
       done();
     });
   });
@@ -70,7 +70,7 @@ describe('Fetch fumors', () => {
 
   it('should not get a single rumor with wrong id', (done) => {
     chai.request(app).get('/api/v1/rumors/' + exampleRumorId + 344).end((err, res) => {
-      res.should.have.status(404);
+      res.should.have.status(400);
       res.body.should.be.a('object');
       res.body.should.have.property('error');
       done();
@@ -91,10 +91,20 @@ describe('Update rumor', () => {
   it('should not update a record with wrong id', (done) => {
     chai.request(app).patch('/api/v1/rumors/' + exampleRumorId + 992).send()
       .end((err, res) => {
-        res.should.have.status(404);
+        res.should.have.status(400);
         res.body.should.be.a('object');
         res.body.should.have.property('error');
         done();
       });
+  });
+});
+
+describe('Delete a rumor', () => {
+  it('should delete a rumor', (done) => {
+    chai.request(app).del('/api/v1/rumors/' + exampleRumorId).end((err, res) => {
+      res.should.have.status(200);
+      res.body.should.be.a('object');
+      done();
+    });
   });
 });


### PR DESCRIPTION
**What does this PR do?**
This PR adds functionality to the server to delete a rumor

**Tasks to be completed?**
- get rumor from database
- delete rumor from db
- handle errors and success

**How can this be manually tested?**
- clone the repo
- cd into the project directory
- install mongodb and node js
- run npm i
- set environment variables with .env file
- run npm start 
- send DELETE to `/api/v1/rumors/:id` 

**Relevant PT stories?**
`162875245`