### PR TITLE
#162877449 Add like and unlike rumor

### DIFF
--- a/constrollers/rumor.js
+++ b/constrollers/rumor.js
@@ -119,10 +119,55 @@ const deleteRumor = (req, res) => {
       return res.status(400).json({ status: 400, error: 'An error occurred' });
     });
 };
+
+
+/**
+ * Like or unlike single rumor
+ * @param {Object} req - request object
+ * @param {Object} res - response object
+ * @return {Object} - response object
+ */
+const like = (req, res) => {
+  const userId = 8990;
+  let messageSuccess;
+  const rumorId = req.params.id;
+  Rumor.findOne({ _id: rumorId }).exec().then((rumorData) => {
+    if (!rumorData) {
+      return res.status(404).json({ status: 404, error: 'This Rumor does not exist' });
+    }
+    const newLikes = rumorData.like;
+    if (rumorData.like.includes(userId)) {
+      const userIdIndex = rumorData.like.indexOf(userId);
+      newLikes.splice(userIdIndex, 1);
+      messageSuccess = 'Rumor unliked!';
+    } else {
+      newLikes.push(userId);
+      messageSuccess = 'Rumor liked!';
+    }
+    console.log(newLikes);
+    Rumor.updateOne({ _id: rumorId }, {
+      $set: {
+        like: newLikes,
+      },
+    }).exec().then(() => res.status(200).json({
+      status: 200,
+      data: [{ id: rumorId, message: messageSuccess }],
+    }))
+      .catch((error) => {
+        console.log(error);
+        return res.status(400).json({ status: 400, error: 'An error occurred' });
+      });
+  })
+    .catch((error) => {
+      console.log(error);
+      res.status(400).json({ status: 400, error: 'An error occurred' });
+    });
+};
 export {
   create,
   getAll,
   getSingle,
   update,
   deleteRumor,
+  like,
 };

--- a/models/Rumor.js
+++ b/models/Rumor.js
@@ -6,7 +6,7 @@ const rumorScehma = mongoose.Schema({
   content: { type: String, required: true },
   location: { type: String },
   image: String,
-  like: { type: Array },
+  like: { type: Array, default: [0, 30903, 93993] },
   comment: { type: mongoose.Schema.Types.ObjectId, ref: 'Comment', required: false },
   created_at: { type: Date, default: Date.now },
 });

--- a/routes/rumor.js
+++ b/routes/rumor.js
@@ -5,6 +5,7 @@ import {
   getSingle,
   update,
   deleteRumor,
+  like,
 } from '../constrollers/rumor';
 import validator from '../helpers/validators';
 import handleValidation from '../helpers/handle-validation';
@@ -16,4 +17,5 @@ rumorRouter.get('/', getAll);
 rumorRouter.get('/:id', getSingle);
 rumorRouter.patch('/:id', validator('update-rumor'), handleValidation, update);
 rumorRouter.delete('/:id', deleteRumor);
+rumorRouter.get('/:id/like', like);
 export default rumorRouter;

--- a/test/rumor.js
+++ b/test/rumor.js
@@ -99,6 +99,25 @@ describe('Update rumor', () => {
   });
 });
 
+describe('Like rumor', () => {
+  it('should like a rumor', (done) => {
+    chai.request(app).get('/api/v1/rumors/' + exampleRumorId + '/like')
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.be.a('object');
+        done();
+      });
+  });
+  it('should like a rumor', (done) => {
+    chai.request(app).get('/api/v1/rumors/' + exampleRumorId + '/like')
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.should.be.a('object');
+        done();
+      });
+  });
+});
+
 describe('Delete a rumor', () => {
   it('should delete a rumor', (done) => {
     chai.request(app).del('/api/v1/rumors/' + exampleRumorId).end((err, res) => {


### PR DESCRIPTION
**What does this PR do?**
This PR adds functionality to the server enabling an api consumer to like a rumor and unlike it

**Tasks to be completed?**
- get a user id
- check if the user has liked the rumor
- like or unlike
- return success or error
- test new feature

**How can this be manually tested?**
- clone the repo
- cd into the project directory
- install mongodb and node js
- run npm i
- set environment variables with .env file
- run npm start 
- send POST to `/api/v1/rumors/:id/like` 

*Relevant PT stories?**
`162877449`